### PR TITLE
[HEENDY-98-deploy-admin] 어드민 프론트 S3 배포

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "https://adventure-of-heendy.site"
 }

--- a/src/services/couponService.js
+++ b/src/services/couponService.js
@@ -9,7 +9,7 @@
 
 import axios from 'axios';
 
-const BASE_URL = '/api/v1/admin/coupons'; 
+const BASE_URL = `${process.env.REACT_APP_API_BASE_URL}/api/v1/admin/events`;
 
 const AUTH_HEADERS = { 
     'Authorization': `Bearer ${process.env.REACT_APP_AUTH_TOKEN}`

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -8,7 +8,7 @@
 
 import axios from "axios";
 
-const BASE_URL = "/api/v1/admin/events";
+const BASE_URL = `${process.env.REACT_APP_API_BASE_URL}/api/v1/admin/events`;
 
 const AUTH_HEADERS = {
   Authorization: `Bearer ${process.env.REACT_APP_AUTH_TOKEN}`,

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,8 +1,7 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
 module.exports = function (app) {
-  // process.env.REACT_APP_BACK_SERVER_URL
-  const target = "http://localhost:8080";
+  const target = process.env.REACT_APP_BACK_SERVER_URL;
 
   app.use(
     "/api/v1",


### PR DESCRIPTION
## 구현 내용
- admin 소켓 간단 시연용으로 수동배포
- `npm run build`로 빌드 후 S3 버킷에 업로드, Route53에서 도메인 구매하고 CloudFront SSL 인증서 붙임

## 참고 사항
- https://d2v7bzcwww4s3e.cloudfront.net/
- https://adventure-of-heendy-admin.com/
- 실서버 유저용이랑 실서버 어드민용 소켓 잘 됩니다!

## 참고한 포스팅
- [AWS S3로 React 배포하기](https://velog.io/@krkorklo58/AWS-S3로-React-배포하기)